### PR TITLE
163478803 user can add tags to article

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,6 +19,7 @@
     "import/prefer-default-export": 0,
     "import/no-unresolved": [2, { "commonjs": true }],
     "func-names": 0,
+    "max-len":"off",
     "import/named": 0,
     "arrow-body-style": 0,
     "no-shadow": ["error", { "allow": ["req", "res", "err"] }],

--- a/server/api/middlewares/validation/schemas/article.js
+++ b/server/api/middlewares/validation/schemas/article.js
@@ -6,6 +6,7 @@ const body = Joi.string().min(20).required();
 const authorId = Joi.string();
 const references = Joi.array().items(Joi.string());
 const categoryId = Joi.number().required();
+const tags = Joi.string();
 
 export const newArticleSchema = {
   slug,
@@ -14,4 +15,5 @@ export const newArticleSchema = {
   authorId,
   references,
   categoryId,
+  tags
 };

--- a/server/migrations/20190204153144-create-tags.js
+++ b/server/migrations/20190204153144-create-tags.js
@@ -9,8 +9,17 @@ module.exports = {
       defaultValue: Sequelize.literal('uuid_generate_v4()')
     },
     tagText: {
+      allowNull: false,
       type: Sequelize.TEXT
     },
+    createdAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    },
+    updatedAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    }
   }),
   down: queryInterface => queryInterface.dropTable('Tag')
 };

--- a/server/migrations/20190204153340-create-tags-article.js
+++ b/server/migrations/20190204153340-create-tags-article.js
@@ -3,23 +3,19 @@ module.exports = {
     tagId: {
       allowNull: false,
       type: Sequelize.UUID,
-      defaultValue: Sequelize.literal('uuid_generate_v4()'),
       onDelete: 'CASCADE',
       references: {
         model: 'Tag',
         key: 'id',
-        as: 'tagId',
       },
     },
     articleId: {
       allowNull: false,
       type: Sequelize.UUID,
-      defaultValue: Sequelize.literal('uuid_generate_v4()'),
       onDelete: 'CASCADE',
       references: {
         model: 'Article',
-        key: 'id',
-        as: 'articleId',
+        key: 'id'
       },
     },
   }),

--- a/server/models/articles.js
+++ b/server/models/articles.js
@@ -44,9 +44,10 @@ module.exports = (sequelize, DataTypes) => {
     });
     Article.belongsToMany(models.Tag, {
       foreignKey: 'articleId',
+      otherKey: 'tagId',
       through: 'TagArticle',
-      as: 'ArticleTag',
-      onDelete: 'CASCADE'
+      as: 'tags',
+      timestamps: false,
     });
   };
   return Article;

--- a/server/models/tags.js
+++ b/server/models/tags.js
@@ -1,14 +1,6 @@
 module.exports = (sequelize, DataTypes) => {
   const Tag = sequelize.define('Tag', {
-    tagText: DataTypes.TEXT
+    tagText: DataTypes.TEXT,
   });
-
-  Tag.associate = (models) => {
-    Tag.belongsToMany(models.Article, {
-      foreignKey: 'articleId',
-      through: 'TagArticle',
-      as: 'tagArticles',
-    });
-  };
   return Tag;
 };

--- a/server/seeders/20190210162858-demo-category.js
+++ b/server/seeders/20190210162858-demo-category.js
@@ -1,0 +1,11 @@
+module.exports = {
+  up: (queryInterface) => {
+    return queryInterface.bulkInsert('Category', [{
+      categoryName: 'tech',
+    }], {});
+  },
+
+  down: (queryInterface) => {
+    return queryInterface.bulkDelete('Category', null, {});
+  }
+};

--- a/tests/article/article.js
+++ b/tests/article/article.js
@@ -54,7 +54,7 @@ describe('Tests for article resource', () => {
         .send(invalidArticle);
       expect(res).to.have.status(422);
     });
-    it('should create an article when a current valid user', async () => {
+    it('should create an article with a valid current user token ', async () => {
       const res = await chai.request(app)
         .post('/api/articles')
         .set('Authorization', `Bearer ${userToken}`)


### PR DESCRIPTION
#### What does this PR do?
* Implement user should be able to add tags to an article

#### Description of Task to be completed?
* get tags added to an article by user
* format the tags
* insert the tags into the tags table if they do not exist already
* associate tags with articles in articletag table

#### How should this be manually tested?
* Clone the repo and pull this branch `feature/163478803/user-can-add-tags-to-article`
* create an article with tags field. fields should be separated by coma.

#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/163478806