### PR TITLE
#163903940 User should be able to Delete articles made by self

### DIFF
--- a/server/api/controllers/user.js
+++ b/server/api/controllers/user.js
@@ -61,7 +61,7 @@ export const registerUser = async (req, res) => {
         link
       },
     });
-  } catch (e) {console.log(e);
+  } catch (e) {
     res.status(500).send({
       status: 'error',
       message: 'Internal server error occured.'

--- a/server/api/middlewares/validation/article.js
+++ b/server/api/middlewares/validation/article.js
@@ -1,5 +1,7 @@
 import Joi from 'joi';
-import { newArticleSchema, createHighlightSchema, ratingSchema } from './schemas/article';
+import {
+  newArticleSchema, createHighlightSchema, ratingSchema, updateArticleSchema
+} from './schemas/article';
 
 /**
 * @export
@@ -48,6 +50,25 @@ export const createHighlightValidator = (req, res, next) => {
 */
 export const ratingValidator = (req, res, next) => {
   Joi.validate(req.body, ratingSchema)
+    .then(() => next())
+    .catch(error => res.status(422).send({
+      status: 'fail',
+      data: {
+        input: error.details[0].message,
+      }
+    }));
+};
+
+/**
+* @export
+* @function updateArticleValidator
+* @param {Object} req - request received
+* @param {Object} res - response object
+* @param {Object} next - next object
+* @returns {Object} next object
+*/
+export const updateArticleValidator = (req, res, next) => {
+  Joi.validate(req.body, updateArticleSchema)
     .then(() => next())
     .catch(error => res.status(422).send({
       status: 'fail',

--- a/server/api/middlewares/validation/schemas/article.js
+++ b/server/api/middlewares/validation/schemas/article.js
@@ -1,10 +1,14 @@
 import Joi from 'joi';
 
 const title = Joi.string().min(10).required();
+const updatedTitle = Joi.string().min(10);
 const description = Joi.string().min(10).required();
+const updateDescription = Joi.string().min(10);
 const body = Joi.string().min(20).required();
+const updateBody = Joi.string().min(20);
 const references = Joi.array().items(Joi.string());
 const categoryId = Joi.number().required();
+const updateCategoryId = Joi.number().integer().min(1);
 const tags = Joi.string();
 const highlight = Joi.string().trim().min(1).required();
 const comment = Joi.string().trim().min(1).required();
@@ -17,6 +21,14 @@ export const newArticleSchema = {
   body,
   references,
   categoryId,
+  tags
+};
+export const updateArticleSchema = {
+  title: updatedTitle,
+  description: updateDescription,
+  body: updateBody,
+  references,
+  categoryId: updateCategoryId,
   tags
 };
 

--- a/server/api/routes/article.js
+++ b/server/api/routes/article.js
@@ -1,11 +1,11 @@
 import { Router } from 'express';
 import passport from 'passport';
 import {
-  newArticleValidator, createHighlightValidator, ratingValidator
+  newArticleValidator, createHighlightValidator, ratingValidator, updateArticleValidator
 } from '../middlewares/validation/article';
 import {
-  createArticle, likeArticle, dislikeArticle, createHighlight, getHighlights, rateArticle,
-  getAllArticles, getArticle
+  createArticle, updateArticle, likeArticle, dislikeArticle, createHighlight, getHighlights, rateArticle,
+  getAllArticles, getArticle, deleteArticle
 } from '../controllers/article';
 import { reportArticle } from '../controllers/reports';
 import commentsRouter from './comment';
@@ -13,6 +13,8 @@ import commentsRouter from './comment';
 const articlesRouter = Router();
 
 articlesRouter.post('/', passport.authenticate('jwt', { session: false }), newArticleValidator, createArticle);
+articlesRouter.put('/:articleId', passport.authenticate('jwt', { session: false }), updateArticleValidator, updateArticle);
+articlesRouter.delete('/:articleId', passport.authenticate('jwt', { session: false }), deleteArticle);
 articlesRouter.patch('/:id/likes', passport.authenticate('jwt', { session: false }), likeArticle);
 articlesRouter.patch('/:id/dislikes', passport.authenticate('jwt', { session: false }), dislikeArticle);
 articlesRouter.post('/:id/highlights',

--- a/tests/mocks/mockArticle.js
+++ b/tests/mocks/mockArticle.js
@@ -15,6 +15,13 @@ export const invalidArticle = {
   references: ['princess.com', 'example.com'],
 };
 
+export const invalidUpdateArticle = {
+  slug: 'Oops',
+  description: 'Just',
+  body: 'Just Saying',
+  categoryId: 0
+};
+
 export const mockHighlight = {
   highlight: 'Mock Highlight',
   comment: 'Mock Comment'


### PR DESCRIPTION
#### What does this PR do?
Implement user can delete their articles

#### How should this be manually tested?
* clone this branch `feature/163903595/Update-Article`
* signup a new user by hitting POST `/api/users` url
* retrieve the user token of the signed up user
* add the token to the authorization header with a bearer string.
* Delete an article by hitting the DELETE `/api/articles/:articleId`
 where articleId is the id of the article

#### Any background context you want to provide?
None

#### What are the relevant pivotal tracker stories?
[User should be able to Delete articles made by self](https://www.pivotaltracker.com/story/show/163903940)

#### Screenshots (if appropriate)
None

#### Questions:
None