### PR TITLE
Add count to getAllArticles

### DIFF
--- a/server/api/controllers/article.js
+++ b/server/api/controllers/article.js
@@ -418,7 +418,7 @@ export const getAllArticles = async ({ query: { n = 0, category } }, res) => {
     queryObj.where = { categoryId: { [Op.eq]: categoryId } };
   }
   try {
-    const articles = await Article.findAll(queryObj);
+    const { rows: articles, count } = await Article.findAndCountAll(queryObj);
     const allArticles = articles.map((article) => {
       article = article.toJSON();
       article.readTime = getReadTime(article.body);
@@ -427,7 +427,8 @@ export const getAllArticles = async ({ query: { n = 0, category } }, res) => {
 
     return res.status(200).send({
       status: 'success',
-      data: allArticles
+      data: allArticles,
+      count
     });
   } catch (err) {
     return res.status(500).send({


### PR DESCRIPTION
### This Pull Request
Adds count to `getAllArticles` route

### Description of completed task
Change `findAll` to `findAndCountAll` in the `getAllArticles` controller and return the resulting count with the response.

### Background Context
In order to complete the pagination task on the frontend I need the count of the total number of articles that match the criteria.